### PR TITLE
Proposal's not rendering when MM available + opting to use HW wallet

### DIFF
--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -22,7 +22,8 @@ import {
 } from './sharedProxyConstants';
 import { MAX_UINT_ETH_BN } from '../utils/ethereum';
 import { MKR } from '../chain/maker';
-
+import { netIdToName } from '../utils/ethereum';
+import { proposalsInit } from './proposals';
 // Constants ----------------------------------------------
 
 // the Ledger subprovider interprets these paths to mean that the last digit is
@@ -371,6 +372,12 @@ export const addHardwareAccount = (address, accountType) => async (
         type: accountType
       })
     );
+
+    if (window.web3) {
+      window.web3.version.getNetwork(async (err, netId) => {
+        dispatch(proposalsInit(netIdToName(netId)));
+      });
+    }
 
     return dispatch({
       type: HARDWARE_ACCOUNT_CONNECTED

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -22,8 +22,7 @@ import {
 } from './sharedProxyConstants';
 import { MAX_UINT_ETH_BN } from '../utils/ethereum';
 import { MKR } from '../chain/maker';
-import { netIdToName } from '../utils/ethereum';
-import { proposalsInit } from './proposals';
+
 // Constants ----------------------------------------------
 
 // the Ledger subprovider interprets these paths to mean that the last digit is
@@ -372,12 +371,6 @@ export const addHardwareAccount = (address, accountType) => async (
         type: accountType
       })
     );
-
-    if (window.web3) {
-      window.web3.version.getNetwork(async (err, netId) => {
-        dispatch(proposalsInit(netIdToName(netId)));
-      });
-    }
 
     return dispatch({
       type: HARDWARE_ACCOUNT_CONNECTED

--- a/src/reducers/metamask.js
+++ b/src/reducers/metamask.js
@@ -121,12 +121,11 @@ export const init = (network = 'mainnet') => async dispatch => {
   dispatch(connectSuccess(network));
   dispatch(updateNetwork(network));
 
-  await dispatch(initWeb3Accounts());
-
   dispatch(voteTallyInit());
   dispatch(proposalsInit(network));
   dispatch(hatInit());
   dispatch(ethInit());
+  await dispatch(initWeb3Accounts());
   dispatch(pollForMetamaskChanges());
 };
 

--- a/test/reducers/metamask.test.js
+++ b/test/reducers/metamask.test.js
@@ -201,7 +201,7 @@ describe('async actions', () => {
       type: reducer.UPDATE_NETWORK,
       payload: { network }
     });
-    expect(store.getActions()[3]).toEqual({
+    expect(store.getActions()[7]).toEqual({
       type: reducer.UPDATE_ADDRESS,
       payload: mockDefaultAccount
     });


### PR DESCRIPTION
[gif of issue](https://i.imgur.com/DfKAWqu.gifv)

[GOV-186](https://makerdao.atlassian.net/browse/GOV-186)

Proposal's need to be initialised when opting to use hardware wallet when MM is available. Request to enable browser provider is triggered but the user never unlocks MM. Unless user unlocks MM, no dispatch is made to the initialise proposals and resolving the `childrenShouldMount` flag in `base.js` to true, thereby not rendering the page.
