### PR TITLE
Language Clarification

### DIFF
--- a/src/components/Onboarding/LockMKR.js
+++ b/src/components/Onboarding/LockMKR.js
@@ -130,8 +130,8 @@ class LockMKR extends React.Component {
           <Grid gridRowGap="l">
             {this.state.step <= 1 && (
               <OnboardingHeader
-                title="Deposit MKR"
-                subtitle="In order to participate in voting, you must deposit MKR
+                title="Lock MKR"
+                subtitle="In order to participate in voting, you must lock your MKR tokens
         into your secure voting contract. The higher the amount, the more impact you’ll have on the system"
               />
             )}


### PR DESCRIPTION
Due to a rounding bug in the user onboarding, users who had less than 1 MKR token could not stake their tokens using the voting dashboard. They were then left only with the instructions on this modal that instructs the user to deposit their tokens in the contract address provided.

However, if the user transfers their mkr tokens to this contract, they are effectively lost. This PR serves to provide more clarity to the description of how the tokens are locked in the contract, and not deposited.

This bug cost me approximately $500.
https://etherscan.io/tx/0x6f9fdda6e537c5acb58b546c5ac224889f4e5128021fabcbf32f2aca1a2df620