### PR TITLE
fix rounding in mkr balance

### DIFF
--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -125,7 +125,7 @@ export const addAccounts = accounts => async dispatch => {
       return {
         proxyRole: otherRole,
         address: linkedAddress,
-        mkrBalance: await toNum(mkrToken.balanceOf(linkedAddress))
+        mkrBalance: await toNum(await mkrToken.balanceOf(linkedAddress))
       };
     };
 
@@ -208,9 +208,12 @@ export const addSingleWalletAccount = account => async dispatch => {
   const _payload = {
     ...account,
     address: account.address,
-    mkrBalance: promiseRetry({
-      fn: async () => (await mkrToken.balanceOf(account.address)).toFixed()
-    }),
+    // mkrBalance: promiseRetry({
+    //   fn: async () => (await mkrToken.balanceOf(account.address)).toFixed()
+    // }),
+    mkrBalance: toNum(
+      promiseRetry({ fn: () => mkrToken.balanceOf(account.address) })
+    ),
     hasProxy: false,
     singleWallet: true,
     proxyRole: '',

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -217,7 +217,7 @@ export const toBN = val => val.toBigNumber();
 
 export const toNum = async promise => {
   const val = await promise;
-  return val.toBigNumber().toFixed();
+  return val.toBigNumber().toFixed(4);
 };
 
 export const addMkrAndEthBalance = async account => {


### PR DESCRIPTION
 for governance dashboard, the MKR balance was getting rounded to 0 precision decimals and then in some places forced back to 4 decimal precision.  This addresses the two places I identified that happening (in the MKR locking functionality for a single wallet and in the banner after clicking Save and Exit on that screen. 

Summary of changes:
- change `toFixed()` to `toFixed(4)` in `utils.toNum()`
- use toNum in second accounts payload instead of directly calling `toFixed()`

reference: 
- https://github.com/makerdao/governance-dashboard/issues/78

possibly related to: 
- https://github.com/makerdao/governance-dashboard/pull/77