### PR TITLE
User voting status not displayed

### DIFF
--- a/src/pages/Polling.js
+++ b/src/pages/Polling.js
@@ -344,6 +344,10 @@ class Polling extends React.Component {
     }
   }
 
+  componentDidMount() {
+    this.updateVotedPollOption();
+  }
+
   updateVotedPollOption = async () => {
     if (!this.props.poll || !this.state.activeAccount) return null;
     await this.props.getOptionVotingFor(
@@ -429,7 +433,7 @@ class Polling extends React.Component {
                 poll={poll}
                 optionVotingFor={optionVotingForName}
                 optionVotingForId={optionVotingFor}
-                voteStateFetching={voteStateFetching && accountDataFetching}
+                voteStateFetching={voteStateFetching || accountDataFetching}
                 withdrawVote={this.withdrawVote}
                 modalOpen={modalOpen}
                 totalVotes={totalVotes}


### PR DESCRIPTION
When the user navigates to a poll they have voted on from `/` -> `/polling` -> `/polling/qmu1x2y3z...` their voting status will not be displayed
