### PR TITLE
disallow line breaks in the tag component

### DIFF
--- a/src/pages/Timeline.js
+++ b/src/pages/Timeline.js
@@ -64,6 +64,7 @@ const StyledCard = styled(Card)`
 `;
 
 const Tag = styled.p`
+  white-space: nowrap;
   padding: 1px 10px;
   border-radius: 4px;
   line-height: 21px;


### PR DESCRIPTION
now the `governing proposal` tag is one line. this one had been poking at me for a while


<img width="730" alt="Screen Shot 2019-12-13 at 12 08 52 PM" src="https://user-images.githubusercontent.com/24902242/70818305-5ae33000-1da1-11ea-9d65-900956bd135c.png">
