### PR TITLE
Polling speed up

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@craco/craco": "^3.5.0",
     "@makerdao/dai": "^0.16.1",
     "@makerdao/dai-plugin-config": "^0.2.7-rc.3",
-    "@makerdao/dai-plugin-governance": "0.7.4-rc.2",
+    "@makerdao/dai-plugin-governance": "0.9.1-rc.1",
     "@makerdao/dai-plugin-ledger-web": "^0.9.7",
     "@makerdao/dai-plugin-trezor-web": "^0.9.6",
     "@makerdao/ui-components": "1.0.0-alpha.29",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -46,3 +46,4 @@ const expr = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.
 export const URL_REGEX = new RegExp(expr);
 
 export const MIN_MKR_PERCENTAGE = 0.01;
+export const POSTGRES_MAX_INT = 2147483647;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,10 +1087,10 @@
     babel-runtime "^6.26.0"
     ramda "^0.26.1"
 
-"@makerdao/dai-plugin-governance@0.7.4-rc.2":
-  version "0.7.4-rc.2"
-  resolved "https://registry.yarnpkg.com/@makerdao/dai-plugin-governance/-/dai-plugin-governance-0.7.4-rc.2.tgz#b21dcf0253f8eb38ee79723b783d10c262a93ae3"
-  integrity sha512-cmPO6o1W/rw7CTNbzTO3TVftWwRwPczrNB1YQduqgZHEyXA9+sKdGDs1OGnyYJwrodMG3FkrysoztWICIe8ekw==
+"@makerdao/dai-plugin-governance@0.9.1-rc.1":
+  version "0.9.1-rc.1"
+  resolved "https://registry.yarnpkg.com/@makerdao/dai-plugin-governance/-/dai-plugin-governance-0.9.1-rc.1.tgz#07a31cc24260cfd633c3489cd17e67d34bcb753b"
+  integrity sha512-t2vszLexLMJnMqFuTPIdS20Q9sd3pqO1jVop6q8I9BdLeKXtJVdCQ8lluyZcCGZ6StzhGrUiSCT6k4RpJ41fuQ==
   dependencies:
     "@babel/runtime" "^7.4.3"
     "@makerdao/currency" "^0.9.5"


### PR DESCRIPTION
One insight behind this PR: `getBlockNumber` only needs to be called if the poll is finished -- otherwise, mkr support for current block can be used.