### PR TITLE
GOV 307

### DIFF
--- a/src/pages/Timeline.js
+++ b/src/pages/Timeline.js
@@ -13,6 +13,7 @@ import Vote from '../components/modals/Vote';
 import TillHat from '../components/TillHatMeta';
 import ExtendedLink from '../components/Onboarding/shared/ExtendedLink';
 import { Banner, BannerBody, BannerContent } from '../components/Banner';
+import WithTally from '../components/hocs/WithTally';
 
 const riseUp = keyframes`
 0% {
@@ -73,10 +74,10 @@ const Tag = styled.p`
   margin: auto;
   display: inline-block;
   margin-right: ${({ mr }) => (mr ? `${mr}px` : '')};
-  background-color: ${({ green, lavender }) =>
-    green ? '#c3f5ea' : lavender ? '#EDEFFF' : '#ECF1F3'};
-  color: ${({ green, lavender }) =>
-    green ? '#139D8D' : lavender ? '#48495F' : '#31424E'};
+  background-color: ${({ green, lavender, powder }) =>
+    green ? '#c3f5ea' : lavender ? '#EDEFFF' : powder ? '#EDF5F9' : '#ECF1F3'};
+  color: ${({ green, lavender, powder }) =>
+    green ? '#139D8D' : lavender ? '#48495F' : powder ? '#31424E' : '#31424E'};
 `;
 
 const Bold = styled.span`
@@ -322,7 +323,25 @@ const Timeline = ({
                   <div>
                     <Tag>{'Ready to be passed'}</Tag>
                   </div>
-                ) : null}
+                ) : (
+                  <div>
+                    <WithTally candidate={proposal.source}>
+                      {spellDetails =>
+                        spellDetails.loadingApprovals ? null : (
+                          <Tag powder>
+                            Competing proposal.{' '}
+                            <Bold>
+                              {formatRound(
+                                hat.approvals - spellDetails.approvals
+                              ) + ' MKR'}
+                            </Bold>{' '}
+                            needed to pass.
+                          </Tag>
+                        )
+                      }
+                    </WithTally>
+                  </div>
+                )}
               </ProposalDetails>
               <div>
                 <Fragment>

--- a/src/pages/Timeline.js
+++ b/src/pages/Timeline.js
@@ -329,7 +329,6 @@ const Timeline = ({
                       {spellDetails =>
                         spellDetails.loadingApprovals ? null : (
                           <Tag powder>
-                            Competing proposal.{' '}
                             <Bold>
                               {formatRound(
                                 hat.approvals - spellDetails.approvals


### PR DESCRIPTION
[ticket](https://makerdao.atlassian.net/browse/GOV-307)

Uses the hat data already in redux to show how much MKR is needed for unpassed spells to become the hat. Note that this does not display anything for proposals that have been passed and it does not restore old, previously removed proposals if they all of a sudden regain the hat (this would require a change to the cms).

screenshot:
<img width="1161" alt="Screen Shot 2020-02-13 at 2 36 36 PM" src="https://user-images.githubusercontent.com/24902242/74471516-50f7af00-4e6e-11ea-82fd-46f440e2dccc.png">
